### PR TITLE
Removed the weird TF2 icon in the main menu settings menu

### DIFF
--- a/resource/ui/base/mainmenuoverride.res
+++ b/resource/ui/base/mainmenuoverride.res
@@ -894,7 +894,7 @@
 		{
 			"ControlName"	"ImagePanel"
 			"fieldName"		"MOTD_HeaderIcon"
-			"xpos"			"265"
+			"xpos"			"9999"
 			"ypos"			"25"
 			"zpos"			"100"
 			"wide"			"25"


### PR DESCRIPTION
idk if this is intentional, and if it is, I assume it's not supposed to be on top of buttons.